### PR TITLE
Note loction of built Cyber binary in build.md

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -36,6 +36,8 @@ zig build cli -Drelease-fast -Dtarget=aarch64-macos.12-none
 zig build cli
 ```
 
+If all goes well, the Cyber CLI executable will be located at `./zig-out/cyber/cyber`.
+
 ## Build as a Library.
 When using Cyber as a API library, you'll need to build a library instead.
 ```sh

--- a/docs/build.md
+++ b/docs/build.md
@@ -36,7 +36,7 @@ zig build cli -Drelease-fast -Dtarget=aarch64-macos.12-none
 zig build cli
 ```
 
-If all goes well, the Cyber CLI executable will be located at `./zig-out/cyber/cyber`.
+If all goes well, the Cyber CLI executable will be located in `./zig-out/cyber`.
 
 ## Build as a Library.
 When using Cyber as a API library, you'll need to build a library instead.
@@ -50,6 +50,8 @@ zig build lib -Drelease-fast -Dtarget=aarch64-macos.12-none
 # For Web/WASM.
 zig build lib -Drelease-fast -Dtarget=wasm32-freestanding
 ```
+
+You'll find the resulting shared library in `./zig-out/lib`.
 
 ## Troubleshooting.
 - If you have trouble building mimalloc on MacOS, consider changing the sdk path in `lib/mimalloc/lib.zig` to your installed version.


### PR DESCRIPTION
When building the Cyber binary, I had to take a minute to find where the actually executable CLI file was located. Thought we could add that information to the Build guide.

Don't know why git is showing that I edited the last line of the file... I didn't meant to!