### PR TITLE
Add link to AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ curl -fsSL https://cyberscript.dev/install.sh | bash
 curl -fsSL https://raw.githubusercontent.com/fubark/cyber/master/install.sh | bash
 ```
 - Install from [Downloads](https://github.com/fubark/cyber/releases).
-- Arch Linux User Repository (AUR): [cyber](https://aur.archlinux.org/packages/cyber)
+- Packages
+  - Arch Linux User Repository (AUR): [cyber](https://aur.archlinux.org/packages/cyber), [cyber(alternative)](https://aur.archlinux.org/packages/cyberscript)

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ curl -fsSL https://cyberscript.dev/install.sh | bash
 curl -fsSL https://raw.githubusercontent.com/fubark/cyber/master/install.sh | bash
 ```
 - Install from [Downloads](https://github.com/fubark/cyber/releases).
+- Arch Linux User Repository (AUR): [cyber](https://aur.archlinux.org/packages/cyber)


### PR DESCRIPTION
I'm installing on multiple machines, so I made the PKGBUILD. I've just pushed it to the AUR.

`yay -S cyber`
 
@fubark  when you want ownership over the AUR package, just let me know. Also when the project matures it would be nice to have a versioned tag for each release. If there is any interest from other users I can add multi architecture support.