### PR TITLE
Fix Type Names

### DIFF
--- a/docs/hugo/content/docs/toc/type-system.md
+++ b/docs/hugo/content/docs/toc/type-system.md
@@ -64,7 +64,7 @@ print add(3, 4)
 
 ## Static typing.
 In Cyber, types can be optionally declared with variables, parameters, and return values.
-The following builtin types are available in every namespace: `bool`, `float`, `int`, `string`, `list`, `map`, `error`, `fiber`, `any`.
+The following builtin types are available in every namespace: `bool`, `float`, `int`, `string`, `List`, `Map`, `error`, `fiber`, `any`.
 
 A `type object` declaration creates a new object type.
 ```cy


### PR DESCRIPTION
`list` and `map` are not valid names for `List` and `Map`